### PR TITLE
検索結果、トップ検索窓

### DIFF
--- a/public/tablericons/arrow-left.svg
+++ b/public/tablericons/arrow-left.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M5 12l14 0" />
+  <path d="M5 12l6 6" />
+  <path d="M5 12l6 -6" />
+</svg>

--- a/public/tablericons/heart.svg
+++ b/public/tablericons/heart.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="#ffffff" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M19.5 12.572l-7.5 7.428l-7.5 -7.428a5 5 0 1 1 7.5 -6.566a5 5 0 1 1 7.5 6.572" />
+</svg>

--- a/public/tablericons/search.svg
+++ b/public/tablericons/search.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" />
+  <path d="M21 21l-6 -6" />
+</svg>

--- a/public/tablericons/tools-kitchen-2.svg
+++ b/public/tablericons/tools-kitchen-2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M19 3v12h-5c-.023 -3.681 .184 -7.406 5 -12zm0 12v6h-1v-3m-10 -14v17m-3 -17v3a3 3 0 1 0 6 0v-3" />
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,10 @@
+import SearchBox from "@/search/SearchBox";
+
 export default function Home() {
-  return <main className="text-red-500">page</main>;
+  return (
+    <main className="text-red-500">
+      page
+      <SearchBox />
+    </main>
+  );
 }

--- a/src/app/search/[slug]/page.tsx
+++ b/src/app/search/[slug]/page.tsx
@@ -1,0 +1,45 @@
+import SearchBox from "@/search/SearchBox";
+import SearchChefResults from "@/search/SearchChefResults";
+import SearchRecipeResults from "@/search/SearchRecipeResults";
+import SearchTab from "@/search/SearchTab";
+import { type ChefResponse, type RecipeResponse } from "@/search/types/results";
+
+type Props = {
+  params: {
+    slug: string;
+  };
+  searchParams: {
+    q?: string;
+  };
+};
+
+export default async function Page({ params, searchParams }: Props) {
+  if (searchParams.q === undefined) {
+    searchParams.q = "";
+  }
+
+  const chefs = (await fetch(`https://29xu9p1l3f.microcms.io/api/v1/chef?q=${encodeURIComponent(searchParams.q)}`, {
+    headers: {
+      "X-MICROCMS-API-KEY": "TsyPrNWEO382U41DYsQrZFL2TlIDE2wuNK4v",
+    },
+    next: { revalidate: 60 },
+  }).then((res) => res.json())) as ChefResponse;
+
+  const recipes = (await fetch(`https://29xu9p1l3f.microcms.io/api/v1/recipe?q=${encodeURIComponent(searchParams.q)}`, {
+    headers: {
+      "X-MICROCMS-API-KEY": "TsyPrNWEO382U41DYsQrZFL2TlIDE2wuNK4v",
+    },
+    next: { revalidate: 60 },
+  }).then((res) => res.json())) as RecipeResponse;
+
+  return (
+    <>
+      <SearchBox type={params.slug} />
+      <SearchTab type={params.slug} basePath="/search" q={searchParams.q} />
+
+      {params.slug !== "recipe" && <SearchChefResults chefs={chefs} />}
+
+      {params.slug !== "chef" && <SearchRecipeResults recipes={recipes} />}
+    </>
+  );
+}

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -1,0 +1,11 @@
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function SearchLayout({ children }: Props) {
+  return (
+    <section>
+      <div className="min-w-[360px] max-w-lg">{children}</div>
+    </section>
+  );
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+
+import SearchBox from "@/search/SearchBox";
+import SearchChefResults from "@/search/SearchChefResults";
+import SearchRecipeResults from "@/search/SearchRecipeResults";
+import SearchTab from "@/search/SearchTab";
+import { type ChefResponse, type RecipeResponse } from "@/search/types/results";
+
+const Title = ({ text, type, q }: { text: string; type: string; q: string }) => {
+  return (
+    <div className="flex items-center justify-between px-4">
+      <p className="text-xl font-bold">{text}</p>
+      <p className="text-base text-[#908E96]">
+        <Link
+          href={{
+            pathname: `/search/${encodeURIComponent(type)}`,
+            query: { q },
+          }}
+        >
+          もっとみる
+        </Link>
+      </p>
+    </div>
+  );
+};
+
+type Props = {
+  params: {
+    type: string;
+  };
+  searchParams: {
+    q?: string;
+  };
+};
+
+export default async function Page({ params, searchParams }: Props) {
+  if (searchParams.q === undefined) {
+    searchParams.q = "";
+  }
+
+  if (params.type === undefined) {
+    params.type = "all";
+  }
+
+  const chefs = (await fetch(
+    `https://29xu9p1l3f.microcms.io/api/v1/chef?limit=3&q=${encodeURIComponent(searchParams.q)}`,
+    {
+      headers: {
+        "X-MICROCMS-API-KEY": "TsyPrNWEO382U41DYsQrZFL2TlIDE2wuNK4v",
+      },
+      next: { revalidate: 60 },
+    }
+  ).then((res) => res.json())) as ChefResponse;
+
+  const recipes = (await fetch(
+    `https://29xu9p1l3f.microcms.io/api/v1/recipe?limit=5&q=${encodeURIComponent(searchParams.q)}`,
+    {
+      headers: {
+        "X-MICROCMS-API-KEY": "TsyPrNWEO382U41DYsQrZFL2TlIDE2wuNK4v",
+      },
+      next: { revalidate: 60 },
+    }
+  ).then((res) => res.json())) as RecipeResponse;
+
+  return (
+    <>
+      <SearchBox type={params.type} />
+      <SearchTab type={params.type} basePath="/search" q={searchParams.q} />
+
+      <Title text="シェフ" type="chef" q={searchParams.q} />
+      <SearchChefResults chefs={chefs} />
+
+      <Title text="レシピ" type="recipe" q={searchParams.q} />
+      <SearchRecipeResults recipes={recipes} />
+    </>
+  );
+}

--- a/src/search/SearchBox/index.module.css
+++ b/src/search/SearchBox/index.module.css
@@ -1,0 +1,18 @@
+.searchField {
+  box-sizing: border-box;
+  padding: 7px 24px 7px 16px;
+  border: 1px solid #eeedef;
+  border-radius: 12px;
+  width: 100%;
+  background: url("/tablericons/search.svg") no-repeat 16px -2em #eeedef;
+  color: #1a1523;
+}
+
+.searchField::placeholder {
+  color: #908e96;
+}
+
+.searchField:placeholder-shown {
+  padding-left: 48px;
+  background-position: 16px center;
+}

--- a/src/search/SearchBox/index.tsx
+++ b/src/search/SearchBox/index.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+
+import styles from "./index.module.css";
+
+type Props = {
+  type?: string;
+};
+
+export default function SearchBox({ type = "all" }: Props) {
+  const pathname = usePathname();
+  const isSearch = pathname.includes("search");
+  const [composing, setComposition] = useState(false);
+  const onKeyDownHandler: React.KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (e) => {
+      if (e.code === "Enter" && !composing) {
+        location.href = `/search${type === "all" ? "" : "/" + type}?q=${inputRef.current?.value}`;
+      }
+    },
+    [composing, type]
+  );
+  const inputRef = useRef<HTMLInputElement>(null);
+  const searchParams = useSearchParams();
+  const defaultQuery = searchParams.get("q") || "";
+  return (
+    <div className="flex max-w-lg p-4 align-middle">
+      <Link href="/" className={`flex items-center pr-4 ${isSearch ? "" : "hidden"}`}>
+        <Image src="/tablericons/arrow-left.svg" width={28} height={28} alt="" />
+      </Link>
+      <input
+        type="search"
+        name="q"
+        ref={inputRef}
+        className={styles.searchField}
+        placeholder="シェフやレシピを検索"
+        onKeyDown={onKeyDownHandler}
+        onCompositionStart={() => setComposition(true)}
+        onCompositionEnd={() => setComposition(false)}
+        defaultValue={defaultQuery}
+      />
+    </div>
+  );
+}

--- a/src/search/SearchChefResults/index.tsx
+++ b/src/search/SearchChefResults/index.tsx
@@ -1,0 +1,48 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { type ChefResponse } from "@/search/types/results";
+
+type Props = {
+  chefs?: ChefResponse;
+};
+
+export default function SearchChefResults({ chefs }: Props) {
+  if (!chefs) {
+    return null;
+  }
+  if (chefs.contents.length === 0) {
+    return <p className="p-4 text-sm text-slate-900">シェフの検索結果がありません。</p>;
+  }
+  return (
+    <div className="px-4 pb-12 pt-5">
+      {chefs.contents.map((chef) => (
+        <div key={chef.id}>
+          <Link
+            href={{
+              // pathname: `/chefs/${chef.id}`,
+              pathname: `/`,
+            }}
+            className="flex gap-4 pb-5"
+          >
+            <img
+              src={`${chef.image?.url}?fit=crop&w=88&h=116`}
+              alt=""
+              className="block aspect-[9/12] h-[116px] w-[88px] rounded-lg"
+              width={chef.image?.width}
+              height={chef.image?.height}
+            />
+            <div className="flex-1">
+              <p className="text-base font-bold">{chef.name}</p>
+              <p className="line-clamp-3 pt-1 text-sm text-[#86848D]">{chef.profile}</p>
+              <p className="flex items-center gap-1 pt-1 text-sm">
+                <Image src="/tablericons/tools-kitchen-2.svg" width={16} height={16} alt="" />
+                <span>123レシピ</span>
+              </p>
+            </div>
+          </Link>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/search/SearchRecipeResults/index.tsx
+++ b/src/search/SearchRecipeResults/index.tsx
@@ -1,0 +1,46 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { type RecipeResponse } from "@/search/types/results";
+
+type Props = {
+  recipes?: RecipeResponse;
+};
+
+export default function SearchChefResults({ recipes }: Props) {
+  if (!recipes) {
+    return null;
+  }
+  if (recipes.contents.length === 0) {
+    return <p className="p-4 text-sm text-slate-900">レシピの検索結果がありません。</p>;
+  }
+  return (
+    <div className="grid grid-cols-1 gap-x-3 gap-y-4 px-4 pb-12 pt-5 min-[375px]:grid-cols-2 min-[415px]:grid-cols-3">
+      {recipes.contents.map((recipe) => (
+        <div key={recipe.id} className="relative w-full">
+          <Link
+            href={{
+              // pathname: `/recipes/${recipe.id}`,
+              pathname: `/`,
+            }}
+            className="block"
+          >
+            <img
+              src={`${recipe.thumbnail?.url}?fit=crop&w=174&h=174`}
+              alt=""
+              className="aspect-square h-auto w-full rounded-2xl border-2 border-solid border-gray-300"
+              width={recipe.thumbnail?.width}
+              height={recipe.thumbnail?.height}
+            />
+            <span className="line-clamp-2 pt-2 text-xs font-bold">{recipe.title}</span>
+            <span className="line-clamp-1 pt-1 text-[10px] text-[#6F6E77]">{recipe.description}</span>
+          </Link>
+          <p className="absolute right-2 top-2 box-border flex items-center gap-1 rounded-2xl bg-black/60 px-2 py-[2px] leading-4 text-white">
+            <Image src="/tablericons/heart.svg" width={18} height={18} alt="" />
+            <span className="text-sm">1,234</span>
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/search/SearchTab/index.tsx
+++ b/src/search/SearchTab/index.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+
+type Props = {
+  type?: string;
+  basePath?: string;
+  q: string;
+};
+
+const searchTypes = [
+  {
+    id: "all",
+    name: "すべて",
+  },
+  { id: "chef", name: "シェフ" },
+  { id: "recipe", name: "レシピ" },
+];
+
+export default function SearchTab({ type = "all", basePath = "", q }: Props) {
+  return (
+    <ul className="flex items-center pb-5">
+      {searchTypes.map((p) => (
+        <li
+          className={`flex-1 p-[10px] ${
+            type === p.id
+              ? "border-b-2 border-solid border-black font-bold"
+              : "border-b-2 border-solid border-slate-300"
+          }`}
+          key={p.id}
+        >
+          <Link
+            href={{
+              pathname: p.id === "all" ? basePath : `${basePath}/${p.id}`,
+              query: { q },
+            }}
+            className="flex items-center justify-center"
+          >
+            {p.name}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/search/types/results.ts
+++ b/src/search/types/results.ts
@@ -1,0 +1,40 @@
+// タグの型定義
+export type Tag = {
+  id: string;
+  name: string;
+};
+
+// シェフの型定義
+export type Chef = {
+  id: string;
+  name: string;
+  profile: string;
+  image?: {
+    url: string;
+    width: number;
+    height: number;
+  };
+};
+
+export type ChefResponse = {
+  contents: Chef[];
+};
+
+// レシピの型定義
+export type Recipe = {
+  id: string;
+  title: string;
+  description: string;
+  content: string;
+  thumbnail?: {
+    url: string;
+    width: number;
+    height: number;
+  };
+  tags?: Tag[];
+  chef?: Chef;
+};
+
+export type RecipeResponse = {
+  contents: Recipe[];
+};


### PR DESCRIPTION
## やったこと

検索結果画面、トップ検索窓（コンポーネント）を作成しました

## デザイン

https://www.figma.com/file/JSVMGHBeYzAsmujXjPDwAE/%E4%B8%80%E6%B5%81%E3%83%AC%E3%82%B7%E3%83%94?type=design&node-id=0-1

## 画像/動画

![search](https://github.com/qin-team-recipe/13-recipe-app/assets/26358717/141e2d87-4681-469b-a461-3ee9f6072cd7)

## その他

- 仮データとしてmicroCMSでの入稿データを使用、正式なAPI出来たら差し替えます
- レシピのレイアウトの細かい仕様がないので、幅に応じた、1カラムから3カラムの可変レイアウトにしました